### PR TITLE
fix(get-profile): use loop reading instead of readarray

### DIFF
--- a/get-profile.sh
+++ b/get-profile.sh
@@ -12,7 +12,11 @@ STRING="${STRING//\[profile /}"
 STRING="${STRING//\]/}"
 
 # Create array - requires bash 4
-readarray -t PROFILE_LIST <<< "${STRING}"
+while IFS= read -r line; do
+    PROFILE_LIST+=("$line")
+    echo $line
+done <<< "${STRING}"
+unset IFS
 
 IFS=$'\n' PROFILE_LIST=($(sort <<< "${PROFILE_LIST[*]}"))
 unset IFS


### PR DESCRIPTION
Fix for macOS. (https://stackoverflow.com/questions/23842261/alternative-to-readarray-because-it-does-not-work-on-mac-os-x)